### PR TITLE
Avoid eval in LegacyAuthStore

### DIFF
--- a/docs/Client.js.html
+++ b/docs/Client.js.html
@@ -132,7 +132,8 @@ class Client extends EventEmitter {
         if (isCometOrAbove) {
             await this.pupPage.evaluate(ExposeAuthStore);
         } else {
-            await this.pupPage.evaluate(ExposeLegacyAuthStore, moduleRaid.toString());
+            const mR = await this.pupPage.evaluate(moduleRaid);
+            await this.pupPage.evaluate(ExposeLegacyAuthStore, mR);
         }
 
         const needAuthentication &#x3D; await this.pupPage.evaluate(async () &#x3D;&gt; {

--- a/docs/util_Injected.js.html
+++ b/docs/util_Injected.js.html
@@ -32,10 +32,8 @@
             <pre class="prettyprint linenums"><code>&#x27;use strict&#x27;;
 
 // Exposes the internal Store to the WhatsApp Web client
-exports.ExposeStore &#x3D; (moduleRaidStr) &#x3D;&gt; {
-    eval(&#x27;var moduleRaid &#x3D; &#x27; + moduleRaidStr);
-    // eslint-disable-next-line no-undef
-    window.mR &#x3D; moduleRaid();
+exports.ExposeStore &#x3D; (mR) &#x3D;&gt; {
+    window.mR &#x3D; mR;
     window.Store &#x3D; Object.assign({}, window.mR.findModule(m &#x3D;&gt; m.default &amp;amp;&amp;amp; m.default.Chat)[0].default);
     window.Store.AppState &#x3D; window.mR.findModule(&#x27;Socket&#x27;)[0].Socket;
     window.Store.Conn &#x3D; window.mR.findModule(&#x27;Conn&#x27;)[0].Conn;

--- a/src/Client.js
+++ b/src/Client.js
@@ -101,7 +101,8 @@ class Client extends EventEmitter {
         if (isCometOrAbove) {
             await this.pupPage.evaluate(ExposeAuthStore);
         } else {
-            await this.pupPage.evaluate(ExposeLegacyAuthStore, moduleRaid.toString());
+            const mR = await this.pupPage.evaluate(moduleRaid);
+            await this.pupPage.evaluate(ExposeLegacyAuthStore, mR);
         }
 
         const needAuthentication = await this.pupPage.evaluate(async () => {

--- a/src/util/Injected/AuthStore/LegacyAuthStore.js
+++ b/src/util/Injected/AuthStore/LegacyAuthStore.js
@@ -2,10 +2,8 @@
 
 //TODO: To be removed by version 2.3000.x hard release
 
-exports.ExposeLegacyAuthStore = (moduleRaidStr) => {
-    eval('var moduleRaid = ' + moduleRaidStr);
-    // eslint-disable-next-line no-undef
-    window.mR = moduleRaid();
+exports.ExposeLegacyAuthStore = (mR) => {
+    window.mR = mR;
     window.AuthStore = {};
     window.AuthStore.AppState = window.mR.findModule('Socket')[0].Socket;
     window.AuthStore.Cmd = window.mR.findModule('Cmd')[0].Cmd;
@@ -18,5 +16,4 @@ exports.ExposeLegacyAuthStore = (moduleRaidStr) => {
         ...window.mR.findModule('verifyKeyIndexListAccountSignature')[0],
         ...window.mR.findModule('waNoiseInfo')[0],
         ...window.mR.findModule('waSignalStore')[0],
-    };
-};
+    };};


### PR DESCRIPTION
## Summary
- remove `eval` usage for moduleRaid in legacy auth flow
- pass moduleRaid object directly to injection helpers
- document new injection approach

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da292275883208933dd6adb4b72f7