### PR TITLE
Fix LocalWebCache sanitization and add tests

### DIFF
--- a/src/webCache/LocalWebCache.js
+++ b/src/webCache/LocalWebCache.js
@@ -17,8 +17,20 @@ class LocalWebCache extends WebCache {
         this.strict = options.strict || false;
     }
 
+    _sanitizeVersion(version) {
+        return String(version).replace(/[^0-9.]/g, '');
+    }
+
+    _validateVersion(version) {
+        if(/[\\/]/.test(version)) {
+            throw new Error('Invalid version, path separators are not allowed.');
+        }
+    }
+
     async resolve(version) {
-        const filePath = path.join(this.path, `${version}.html`);
+        this._validateVersion(version);
+        const sanitized = this._sanitizeVersion(version);
+        const filePath = path.join(this.path, `${sanitized}.html`);
         
         try {
             return fs.readFileSync(filePath, 'utf-8');
@@ -30,8 +42,9 @@ class LocalWebCache extends WebCache {
     }
 
     async persist(indexHtml, version) {
-        // version = (version+'').replace(/[^0-9.]/g,'');
-        const filePath = path.join(this.path, `${version}.html`);
+        this._validateVersion(version);
+        const sanitized = this._sanitizeVersion(version);
+        const filePath = path.join(this.path, `${sanitized}.html`);
         fs.mkdirSync(this.path, { recursive: true });
         fs.writeFileSync(filePath, indexHtml);
     }

--- a/tests/localwebcache.js
+++ b/tests/localwebcache.js
@@ -1,0 +1,36 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const fs = require('fs');
+const path = require('path');
+const LocalWebCache = require('../src/webCache/LocalWebCache');
+
+const expect = chai.expect;
+chai.use(chaiAsPromised);
+
+describe('LocalWebCache path handling', function() {
+    let cacheDir;
+    let cache;
+
+    beforeEach(function() {
+        cacheDir = fs.mkdtempSync(path.join(__dirname, 'cache-'));
+        cache = new LocalWebCache({ path: cacheDir });
+    });
+
+    afterEach(function() {
+        fs.rmSync(cacheDir, { recursive: true, force: true });
+    });
+
+    it('sanitizes version to digits and dots', async function() {
+        await cache.persist('html', 'v1.x.2');
+        const expected = path.join(cacheDir, '1.2.html');
+        expect(fs.existsSync(expected)).to.equal(true);
+    });
+
+    it('rejects path separators on persist', async function() {
+        await expect(cache.persist('html', '../evil')).to.be.rejectedWith(Error);
+    });
+
+    it('rejects path separators on resolve', async function() {
+        await expect(cache.resolve('../evil')).to.be.rejectedWith(Error);
+    });
+});


### PR DESCRIPTION
## Summary
- sanitize web cache version strings
- validate that versions do not contain path separators
- add tests covering the LocalWebCache path handling

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da2902b208320a82feb7858da4b07