### PR TITLE
Bump puppeteer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mime": "^3.0.0",
     "node-fetch": "^2.6.9",
     "node-webpmux": "3.1.7",
-    "puppeteer": "^18.2.1"
+    "puppeteer": "^22.11.2"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.12",


### PR DESCRIPTION
## Summary
- update `puppeteer` to `^22.11.2`

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm audit` *(fails: lockfile missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e9703fa8c832085036a15b5b45956